### PR TITLE
Warranty table and route added

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -212,3 +212,19 @@ class CheckoutCart(db.Model):
     last_updated = db.Column(db.DateTime, nullable=False, server_default=db.func.current_timestamp(),
                           onupdate=db.func.current_timestamp())
 
+class Warranty(db.Model):
+    # CheckoutCart table model
+    __tablename__ = 'Warranty'
+    
+    Warranty_ID = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    VIN_carID = db.Column(db.String(45), db.ForeignKey('CarVins.VIN_carID'))
+    addon_ID = db.Column(db.Integer, db.ForeignKey('Addons.itemID'))
+    # memberID = db.Column(db.Integer, db.ForeignKey('Member.memberID'), nullable=False)
+
+
+class WarrantyService(db.Model):
+    # CheckoutCart table model
+    __tablename__ = 'WarrantyService'
+    
+    addon_ID = db.Column(db.Integer, db.ForeignKey('Addons.itemID'),primary_key=True)
+    serviceID = db.Column(db.Integer, db.ForeignKey('Services.serviceID'))

--- a/app/models.py
+++ b/app/models.py
@@ -217,7 +217,7 @@ class Warranty(db.Model):
     __tablename__ = 'Warranty'
     
     Warranty_ID = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    VIN_carID = db.Column(db.String(45), db.ForeignKey('CarVins.VIN_carID'))
+    VIN_carID = db.Column(db.String(17))# there should be fk here but idk why it didnt work
     addon_ID = db.Column(db.Integer, db.ForeignKey('Addons.itemID'))
     # memberID = db.Column(db.Integer, db.ForeignKey('Member.memberID'), nullable=False)
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -835,20 +835,56 @@ def book_test_drive():
 
 
 @app.route('/api/service-menu', methods=['GET'])  # TEST DONE
-# this api i hate it, it made me make another table and have to refactor everything.
-# returns all values in the Services table for users to choose what services they want.
+# Returns all values in the Services table for users to choose what services they want if not vin passed
+# If Vin provided queries the warranties associated with that VIN. If warranties exist, it finds the associated services and marks them as free
 def get_services():
-    if request.method == 'GET':
-        try:
-            services = Services.query.all()
+    try:
+        # Check if VIN is provided in the query parameters
+        vin = request.args.get('vin')   ## /api/service-menu?vin=ABC123
+        
+        if vin:
+            # Query warranties for the provided VIN
+            warranties = Warranty.query.filter_by(VIN_carID=vin).all()
+            if warranties:
+                # If warranties exist, find associated services
+                free_services = set()
+                for warranty in warranties:
+                    warranty_services = WarrantyService.query.filter_by(addon_ID=warranty.addon_ID).all()
+                    for warranty_service in warranty_services:
+                        free_services.add(warranty_service.serviceID)
+                
+                # Query all services
+                services = Services.query.all()
+                
+                # Prepare service info, mark free services
+                services_info = []
+                for service in services:
+                    service_info = {
+                        'serviceID': service.serviceID,
+                        'service_name': service.service_name,
+                        'price': "0.00" if service.serviceID in free_services else service.price
+                    }
+                    services_info.append(service_info)
+            else:
+                # If no warranties found, return all services with regular prices
+                services_info = [{
+                    'serviceID': service.serviceID,
+                    'service_name': service.service_name,
+                    'price': service.price
+                } for service in Services.query.all()]
+        else:
+            # If VIN is not provided, return all services with regular prices
             services_info = [{
                 'serviceID': service.serviceID,
                 'service_name': service.service_name,
                 'price': service.price
-            } for service in services]
-            return jsonify(services_info), 200
-        except Exception as e:
-            return jsonify({'error': str(e)}), 500
+            } for service in Services.query.all()]
+        
+        return jsonify(services_info), 200
+        
+    except Exception as e:
+        # Return error if an exception occurs
+        return jsonify({'error': str(e)}), 500
        
 @app.route('/api/manager/edit-service-menu', methods=['POST', 'DELETE'])  # test ready
 def edit_service_menu():

--- a/sql-database-scripts/production_db/db-schema.sql
+++ b/sql-database-scripts/production_db/db-schema.sql
@@ -253,3 +253,25 @@ CREATE TABLE IF NOT EXISTS checkoutcart (
   CONSTRAINT `serviceID_FK` FOREIGN KEY (`serviceID`) REFERENCES Services(`serviceID`),
   CONSTRAINT `VIN_carID_FK` FOREIGN KEY (`VIN_carID`) REFERENCES CarInfo(`VIN_carID`)
 ) ;
+
+
+CREATE TABLE IF NOT EXISTS warranty (
+  `Warranty_ID` int NOT NULL AUTO_INCREMENT,
+  `VIN_carID` varchar(17) DEFAULT NULL,
+  `addon_ID` int DEFAULT NULL,
+  PRIMARY KEY (`Warranty_ID`),
+  KEY `warranty_vinFK_idx` (`VIN_carID`),
+  KEY `warranty_addonFK_idx` (`addon_ID`),
+  CONSTRAINT `warranty_addonFK` FOREIGN KEY (`addon_ID`) REFERENCES `addons` (`itemID`),
+  CONSTRAINT `warranty_vinFK` FOREIGN KEY (`VIN_carID`) REFERENCES `carvins` (`VIN_carID`)
+) ;
+
+CREATE TABLE IF NOT EXISTS warrantyservice (
+  `addon_ID` int NOT NULL,
+  `serviceID` int DEFAULT NULL,
+  PRIMARY KEY (`addon_ID`),
+  KEY `serviceFK_idx` (`serviceID`),
+  CONSTRAINT `addonFK` FOREIGN KEY (`addon_ID`) REFERENCES `addons` (`itemID`),
+  CONSTRAINT `serviceFK` FOREIGN KEY (`serviceID`) REFERENCES `services` (`serviceID`)
+);
+

--- a/sql-database-scripts/production_db/insert_values_db.sql
+++ b/sql-database-scripts/production_db/insert_values_db.sql
@@ -505,3 +505,7 @@ INSERT INTO Addons (itemName, totalCost) VALUES
 ('Navigation Systems', 1000.00),
 ('Towing Packages', 1000.00),
 ('Entertainment Systems', 800.00);
+
+INSERT INTO warrantyservice (addon_ID, serviceID) VALUES
+(2,1),
+(5,5);


### PR DESCRIPTION
- Ok i got a warranties table to be built and i changed the /api/service-menu endpoint
- So if you call it normally like before it still returns the menu at the regular prices
- but now if you also pass a query in the url with the vin of a car it searches for any warranties associated with that car. If any come up then the warranty associated with that service is 0.00
![image](https://github.com/Hot-Carz-Dealership/Hot-Carz-Dealership-Backend/assets/60024274/97a32033-806d-4129-91dd-bd1ecaa98831)
- Ur probably gonna have to change the frontend so that the user picks their vehicle first and then the service so that way the correct prices show

Also warranty table is updated whenever a purchase is made of any addons on a vehicle