### PR TITLE
fix for railway maybe?

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,7 +24,7 @@ else:
 app.config.from_object(Config)
 
 # Enable Cross-Origin Resource Sharing (CORS)
-CORS(app, supports_credentials=True)
+CORS(app, supports_credentials=True, allow_headers='*')
 
 # Call factory function to create our blueprint
 swaggerui_blueprint = get_swaggerui_blueprint(


### PR DESCRIPTION
Here's what each parameter does:

supports_credentials=True: This option allows users to make authenticated requests by injecting the Access-Control-Allow-Credentials header in responses. This is necessary if your frontend application needs to send credentials (such as cookies or HTTP authentication) to the server.
allow_headers='*': This option allows all headers ('*') to be used when the resource is accessed by allowed origins. This ensures that all headers sent by the frontend application are allowed by the CORS policy.
With these settings, your Flask application should properly handle CORS requests from your frontend application running at http://localhost:3000.